### PR TITLE
feat(Cooks_membrane_nofluid): Implementation of with trac_stab

### DIFF
--- a/examples/IBPD/explicit/Cooks_membrane/generate_sheet2d.cpp
+++ b/examples/IBPD/explicit/Cooks_membrane/generate_sheet2d.cpp
@@ -146,11 +146,22 @@ main(int /*argc*/, char** /*argv*/)
     }
     const int totnode = nnum + 1;
 
+    std::cout << "totnode = " << totnode << std::endl;
+
+
+    /* enumeration of particles represented by o
+    4 o 8 o
+    3 o 7 o
+    2 o 6 o
+    1 o 5 o 
+    0 o 
+    */
     double coord[totnode][2];
     for (int i = 0; i < totnode; ++i)
     {
         coord[i][0] = coord1[i][0];
         coord[i][1] = coord1[i][1];
+        std::cout << "i= " << i << ", coords = " << coord1[i][0] << ", " << coord1[i][1] << std::endl;
     }
 
 
@@ -164,9 +175,9 @@ main(int /*argc*/, char** /*argv*/)
     // Determination of material points inside the horizon of each material point
     int numfam[totnode];
     std::map<Edge, EdgeProp, EdgeComp> mesh;
-    for (int i = 0; i < totnode; ++i)
+    for (int i = 0; i < totnode; ++i) // index of master
     {   numfam[i] = 0;
-        for (int j = 0; j < totnode; ++j)
+        for (int j = 0; j < totnode; ++j) // index of slave
         {
             const double idist = sqrt(pow((coord[j][0] - coord[i][0]), 2) + pow((coord[j][1] - coord[i][1]), 2));
             if (i != j)

--- a/examples/IBPD/explicit/Cooks_membrane/input2d
+++ b/examples/IBPD/explicit/Cooks_membrane/input2d
@@ -13,7 +13,7 @@ U_MAX = 5.0
 
 // model parameters
 HORIZON_SIZE    = 2.015
-POISSON_RATIO   = -1.0
+POISSON_RATIO   = 0.4
 APPRES          = 6.25
 YOUNGS_MOD      = 250
 SHEAR_MOD       = YOUNGS_MOD / 2.0 / (.5 + 1.0)
@@ -58,9 +58,9 @@ CONVECTIVE_OP_TYPE  = "PPM"                    // convective differencing discre
 CONVECTIVE_FORM     = "ADVECTIVE"              // how to compute the convective terms
 NORMALIZE_PRESSURE  = TRUE                     // whether to explicitly force the pressure to have mean zero
 CFL_MAX             = 0.2                      // maximum CFL number
-DT                  = .025*CFL_MAX*DX/U_MAX    // maximum timestep size
-// DT                  = 1.0e-4                   // maximum timestep size
-// END_TIME            = DT                       // final simulation time
+//DT                  = .025*CFL_MAX*DX/U_MAX    // maximum timestep size
+DT                  = 1.0e-4 * DX                   // maximum timestep size
+//END_TIME            = DT                     // final simulation time
 ERROR_ON_DT_CHANGE  = FALSE                    // whether to emit an error message if the time step size changes
 VORTICITY_TAGGING   = FALSE                    // whether to tag cells for refinement based on vorticity thresholds
 TAG_BUFFER          = 1                        // size of tag buffer used by grid generation algorithm


### PR DESCRIPTION
# Under Construction

Estabilization of the deformation gradient was based on bond-associated approach. References:
 - Chen, H. (2018). Bond-associated deformation gradients for peridynamic correspondence model. Mechanics Research Communications, 90, 34-41;
 - Chen, H. (2019). A comparison study on peridynamic models using irregular non-uniform spatial discretization. Computer Methods in Applied Mechanics and Engineering, 345, 539-554.

 To do: 
 - [ ] Change this into an example called "Cooks_membrane_no_fluid"; 
